### PR TITLE
Fix chain straight segment

### DIFF
--- a/crates/geng-draw2d/src/chain.rs
+++ b/crates/geng-draw2d/src/chain.rs
@@ -97,6 +97,9 @@ impl Chain {
                     polygon.push(right);
                     polygon.push(right); // Temp
                     polygon.push(right);
+
+                    prev = current;
+                    current = next;
                     continue;
                 }
 


### PR DESCRIPTION
Having a vertex in the middle of a straight segment (i.e. 3 points on a straight line) used to drop the last point.

Fixed so the rendering is correct now.

Before:
![image](https://github.com/geng-engine/geng/assets/12630585/0c8ce6a5-11a5-4e26-92eb-9ff11edba89c)

After:
![image](https://github.com/geng-engine/geng/assets/12630585/c1804302-b671-4d26-a107-d3c7f6e2e3ce)

