### PR TITLE
`trait Draw2d` now takes `ugli::DrawParameters` as an argument

### DIFF
--- a/crates/geng-draw2d/src/chain.rs
+++ b/crates/geng-draw2d/src/chain.rs
@@ -236,6 +236,7 @@ impl Draw2d for Chain {
         helper: &Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn AbstractCamera2d,
+        parameters: &ugli::DrawParameters,
         transform: mat3<f32>,
     ) {
         let framebuffer_size = framebuffer.size();
@@ -252,10 +253,7 @@ impl Draw2d for Chain {
                 },
                 camera.uniforms(framebuffer_size.map(|x| x as f32)),
             ),
-            ugli::DrawParameters {
-                blend_mode: Some(ugli::BlendMode::straight_alpha()),
-                ..Default::default()
-            },
+            parameters,
         );
     }
 }

--- a/crates/geng-draw2d/src/ellipse.rs
+++ b/crates/geng-draw2d/src/ellipse.rs
@@ -44,6 +44,7 @@ impl Draw2d for Ellipse {
         helper: &Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn AbstractCamera2d,
+        parameters: &ugli::DrawParameters,
         transform: mat3<f32>,
     ) {
         let framebuffer_size = framebuffer.size();
@@ -61,10 +62,7 @@ impl Draw2d for Ellipse {
                 },
                 camera.uniforms(framebuffer_size.map(|x| x as f32)),
             ),
-            ugli::DrawParameters {
-                blend_mode: Some(ugli::BlendMode::straight_alpha()),
-                ..Default::default()
-            },
+            parameters,
         );
     }
 }

--- a/crates/geng-draw2d/src/polygon.rs
+++ b/crates/geng-draw2d/src/polygon.rs
@@ -63,6 +63,7 @@ impl Draw2d for Polygon {
         helper: &Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn AbstractCamera2d,
+        parameters: &ugli::DrawParameters,
         transform: mat3<f32>,
     ) {
         let framebuffer_size = framebuffer.size();
@@ -79,10 +80,7 @@ impl Draw2d for Polygon {
                 },
                 camera.uniforms(framebuffer_size.map(|x| x as f32)),
             ),
-            ugli::DrawParameters {
-                blend_mode: Some(ugli::BlendMode::straight_alpha()),
-                ..Default::default()
-            },
+            parameters,
         );
     }
 }
@@ -151,6 +149,7 @@ impl<T: std::borrow::Borrow<ugli::Texture>> Draw2d for TexturedPolygon<T> {
         helper: &Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn AbstractCamera2d,
+        parameters: &ugli::DrawParameters,
         transform: mat3<f32>,
     ) {
         let framebuffer_size = framebuffer.size();
@@ -169,10 +168,7 @@ impl<T: std::borrow::Borrow<ugli::Texture>> Draw2d for TexturedPolygon<T> {
                 },
                 camera.uniforms(framebuffer_size.map(|x| x as f32)),
             ),
-            ugli::DrawParameters {
-                blend_mode: Some(ugli::BlendMode::straight_alpha()),
-                ..Default::default()
-            },
+            parameters,
         );
     }
 }

--- a/crates/geng-draw2d/src/quad.rs
+++ b/crates/geng-draw2d/src/quad.rs
@@ -23,6 +23,7 @@ impl Draw2d for Quad {
         helper: &Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn AbstractCamera2d,
+        parameters: &ugli::DrawParameters,
         transform: mat3<f32>,
     ) {
         let framebuffer_size = framebuffer.size();
@@ -39,10 +40,7 @@ impl Draw2d for Quad {
                 },
                 camera.uniforms(framebuffer_size.map(|x| x as f32)),
             ),
-            ugli::DrawParameters {
-                blend_mode: Some(ugli::BlendMode::straight_alpha()),
-                ..Default::default()
-            },
+            parameters,
         );
     }
 }
@@ -98,6 +96,7 @@ impl<T: std::borrow::Borrow<ugli::Texture>> Draw2d for TexturedQuad<T> {
         helper: &Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn AbstractCamera2d,
+        parameters: &ugli::DrawParameters,
         transform: mat3<f32>,
     ) {
         let framebuffer_size = framebuffer.size();
@@ -116,10 +115,7 @@ impl<T: std::borrow::Borrow<ugli::Texture>> Draw2d for TexturedQuad<T> {
                 },
                 camera.uniforms(framebuffer_size.map(|x| x as f32)),
             ),
-            ugli::DrawParameters {
-                blend_mode: Some(ugli::BlendMode::straight_alpha()),
-                ..Default::default()
-            },
+            parameters,
         );
     }
 }

--- a/crates/geng-draw2d/src/segment.rs
+++ b/crates/geng-draw2d/src/segment.rs
@@ -66,6 +66,7 @@ impl Draw2d for Segment {
         helper: &Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn AbstractCamera2d,
+        parameters: &ugli::DrawParameters,
         transform: mat3<f32>,
     ) {
         let framebuffer_size = framebuffer.size();
@@ -82,10 +83,7 @@ impl Draw2d for Segment {
                 },
                 camera.uniforms(framebuffer_size.map(|x| x as f32)),
             ),
-            ugli::DrawParameters {
-                blend_mode: Some(ugli::BlendMode::straight_alpha()),
-                ..Default::default()
-            },
+            parameters,
         );
     }
 }

--- a/crates/geng-draw2d/src/text.rs
+++ b/crates/geng-draw2d/src/text.rs
@@ -58,6 +58,7 @@ impl<F: std::borrow::Borrow<Font>, T: AsRef<str>> Draw2d for Text<F, T> {
         _: &Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn AbstractCamera2d,
+        _parameters: &ugli::DrawParameters, // TODO
         transform: mat3<f32>,
     ) {
         self.font.borrow().draw(

--- a/crates/geng/examples/custom_font_shader.rs
+++ b/crates/geng/examples/custom_font_shader.rs
@@ -57,7 +57,7 @@ impl State {
         let font = geng::Font::new(
             geng.ugli(),
             include_bytes!("../../geng-font/src/default.ttf"),
-            geng::font::Options {
+            &geng::font::Options {
                 pixel_size: 64.0,
                 max_distance: 0.25,
                 antialias: true,

--- a/crates/geng/examples/draw/main.rs
+++ b/crates/geng/examples/draw/main.rs
@@ -40,6 +40,7 @@ impl<'a> geng::Draw2d for Grid<'a> {
         helper: &draw2d::Helper,
         framebuffer: &mut ugli::Framebuffer,
         camera: &dyn geng::AbstractCamera2d,
+        parameters: &ugli::DrawParameters,
         transform: mat3<f32>,
     ) {
         for (x, column) in self.table.iter().enumerate() {
@@ -63,6 +64,7 @@ impl<'a> geng::Draw2d for Grid<'a> {
                                     * mat3::scale_uniform(0.5)
                                     * mat3::translate(vec2(1.0, 1.0)),
                             ),
+                        parameters,
                         transform,
                     );
                 }


### PR DESCRIPTION
- `Draw2d::draw2d` and `Draw2d::draw2d_transformed now take draw parameters as an extra argument
- added `Helper::draw_with` method to specify the parameters
- `Helper::draw` now specifies straight alpha blending parameters (so should behave the same way as before)
- `Helper::draw_transformed` also takes parameters as an argument